### PR TITLE
Add bilingual learning direction toggle

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -5,23 +5,26 @@ import SwiftUI
 /// option navigates to the appropriate list view.
 struct ContentView: View {
     @State private var showingSettings = false
+    @AppStorage("learningDirection") private var learningDirection: LearningDirection = .bulgarianToGerman
     
     var body: some View {
         NavigationView {
             VStack(spacing: 0) {
                 // Header with app title and settings
-                HStack {
+                HStack(spacing: 12) {
                     VStack(alignment: .leading, spacing: 4) {
-                        Text("Bulgarian")
+                        Text(learningDirection == .bulgarianToGerman ? "Bulgarisch" : "Немски")
                             .font(.largeTitle)
                             .fontWeight(.bold)
-                        Text("Learning App")
+                        Text(learningDirection == .bulgarianToGerman ? "Lern-App" : "Учебно приложение")
                             .font(.title2)
                             .foregroundColor(.secondary)
                     }
-                    
+
                     Spacer()
-                    
+
+                    DirectionToggle()
+
                     Button(action: {
                         showingSettings = true
                     }) {
@@ -36,16 +39,16 @@ struct ContentView: View {
                 
                 // Main content
                 List {
-                    Section(header: Text("Level A1 - Beginner")) {
+                    Section(header: Text(learningDirection == .bulgarianToGerman ? "Niveau A1 - Anfänger" : "Ниво A1 - начинаещи")) {
                         NavigationLink(destination: VocabularyListView(level: "A1")) {
                             HStack {
                                 Image(systemName: "textformat.abc")
                                     .foregroundColor(.blue)
                                     .frame(width: 30)
                                 VStack(alignment: .leading, spacing: 2) {
-                                    Text("A1 Vocabulary")
+                                    Text(learningDirection == .bulgarianToGerman ? "A1 Vokabeln" : "A1 Лексика")
                                         .font(.headline)
-                                    Text("Basic words and phrases")
+                                    Text(learningDirection == .bulgarianToGerman ? "Grundlegende Wörter und Sätze" : "Основни думи и изрази")
                                         .font(.caption)
                                         .foregroundColor(.secondary)
                                 }
@@ -58,9 +61,9 @@ struct ContentView: View {
                                     .foregroundColor(.green)
                                     .frame(width: 30)
                                 VStack(alignment: .leading, spacing: 2) {
-                                    Text("A1 Grammar")
+                                    Text(learningDirection == .bulgarianToGerman ? "A1 Grammatik" : "A1 Граматика")
                                         .font(.headline)
-                                    Text("Fundamental grammar rules")
+                                    Text(learningDirection == .bulgarianToGerman ? "Grundregeln" : "Основни граматични правила")
                                         .font(.caption)
                                         .foregroundColor(.secondary)
                                 }
@@ -68,16 +71,16 @@ struct ContentView: View {
                         }
                     }
                     
-                    Section(header: Text("Level A2 - Elementary")) {
+                    Section(header: Text(learningDirection == .bulgarianToGerman ? "Niveau A2 - Grundstufe" : "Ниво A2 - средно")) {
                         NavigationLink(destination: VocabularyListView(level: "A2")) {
                             HStack {
                                 Image(systemName: "textformat.abc")
                                     .foregroundColor(.blue)
                                     .frame(width: 30)
                                 VStack(alignment: .leading, spacing: 2) {
-                                    Text("A2 Vocabulary")
+                                    Text(learningDirection == .bulgarianToGerman ? "A2 Vokabeln" : "A2 Лексика")
                                         .font(.headline)
-                                    Text("Extended vocabulary")
+                                    Text(learningDirection == .bulgarianToGerman ? "Erweiterter Wortschatz" : "Разширен речник")
                                         .font(.caption)
                                         .foregroundColor(.secondary)
                                 }
@@ -90,9 +93,9 @@ struct ContentView: View {
                                     .foregroundColor(.green)
                                     .frame(width: 30)
                                 VStack(alignment: .leading, spacing: 2) {
-                                    Text("A2 Grammar")
+                                    Text(learningDirection == .bulgarianToGerman ? "A2 Grammatik" : "A2 Граматика")
                                         .font(.headline)
-                                    Text("Advanced grammar concepts")
+                                    Text(learningDirection == .bulgarianToGerman ? "Fortgeschrittene Grammatik" : "По-напреднала граматика")
                                         .font(.caption)
                                         .foregroundColor(.secondary)
                                 }

--- a/DataStore.swift
+++ b/DataStore.swift
@@ -4,9 +4,9 @@ import Foundation
 ///
 /// The arrays below contain the core data for the beginner (A1) and
 /// elementary (A2) levels.  Each entry supplies the Bulgarian word,
-/// English translation, part of speech, level and optional notes.  The
-/// grammar topics provide concise explanations of major grammatical
-/// concepts along with example sentences.
+/// its German translation, part of speech, level and optional notes.
+/// The grammar topics provide concise explanations of major
+/// grammatical concepts along with example sentences.
 struct DataStore {
     /// All vocabulary items across levels.  You can filter this array by
     /// level to obtain level‑specific lists.
@@ -204,114 +204,5 @@ struct DataStore {
     /// concepts along with illustrative sentences.  Learners can read
     /// these notes to understand Bulgarian grammar fundamentals such
     /// as word order, gender and verb tenses.
-    static let grammarTopics: [GrammarTopic] = [
-        GrammarTopic(
-            title: "Word Order",
-            description: "Bulgarian word order is flexible thanks to subject–verb agreement.\nThe neutral pattern is S + V + O + A (Subject, Verb, Object, Adjunct), but other orders such as A + S + V + O, O + S + V + A or S + V + A + O are also possible.\nYou can change the order to emphasise different parts of the sentence without changing the basic meaning.",
-            examples: [
-                "Той видя момичето в далечината. – He saw the girl in the distance.",
-                "В далечината той видя момичето. – In the distance, he saw the girl.",
-                "Момичето той видя в далечината. – The girl he saw in the distance."
-            ],
-            level: "A1"
-        ),
-        GrammarTopic(
-            title: "Gender of Nouns",
-            description: "Bulgarian nouns have three grammatical genders: masculine, feminine and neuter.\nMasculine nouns usually end in a consonant (мъж – man, син – son).\nFeminine nouns often end in –а/–я (жена – woman, ябълка – apple).\nNeuter nouns typically end in –е/–о (море – sea, месо – meat).\nThere are exceptions: some masculine nouns end in –а/–я (баща – father), some feminine nouns end in a consonant (любов – love), and some neuter nouns end in –и or –ю (такси – taxi).", 
-            examples: [
-                "мъж – man (masculine)",
-                "жена – woman (feminine)",
-                "море – sea (neuter)",
-                "баща – father (masculine ending in –а)",
-                "любов – love (feminine ending in consonant)"
-            ],
-            level: "A1"
-        ),
-        GrammarTopic(
-            title: "Singular and Plural",
-            description: "Bulgarian nouns are either singular or plural.\nMasculine nouns form plurals with endings like –и, –е or –ове (стол – столове 'chair – chairs').\nFeminine nouns replace –а/–я with –и (жена – жени 'woman – women').\nNeuter nouns take –а or –ета (море – морета 'sea – seas').\nA historical dual number for pairs of inanimate masculine nouns survives with the ending –а (два стола – two chairs).", 
-            examples: [
-                "стол – столове (chair – chairs)",
-                "жена – жени (woman – women)",
-                "море – морета (sea – seas)",
-                "два стол а (two chairs – dual form)"
-            ],
-            level: "A1"
-        ),
-        GrammarTopic(
-            title: "Definite Article",
-            description: "The Bulgarian definite article attaches to the end of the noun.\nMasculine nouns take –ът/–ят (студент – студентът 'the student', кон – конят 'the horse').\nFeminine nouns take –та (вода – водата 'the water', чиния – чинията 'the plate').\nNeuter nouns take –то (село – селото 'the village', море – морето 'the sea').\nFor plural nouns the article is –те for masculine and feminine plurals and –та for neuter plurals.",
-            examples: [
-                "студент – студентът (student – the student)",
-                "вода – водата (water – the water)",
-                "село – селото (village – the village)",
-                "мъже – мъжете (men – the men)"
-            ],
-            level: "A1"
-        ),
-        GrammarTopic(
-            title: "Pronouns and Cases",
-            description: "Bulgarian cases exist mainly in personal pronouns.\nThere are three cases: nominative (аз, ти, той, тя, то, ние, вие, те), accusative (ме, те, го, я, го, ни, ви, ги) and dative (ми, ти, му, й, му, ни, ви, им).\nUse the nominative for subjects, the accusative for direct objects and the dative for indirect objects.",
-            examples: [
-                "Аз го попитах как се чувства. – I asked him how he was feeling. (go – accusative)",
-                "Аз му дадох моята книга. – I gave my book to him. (mu – dative)"
-            ],
-            level: "A1"
-        ),
-        GrammarTopic(
-            title: "Present and Future Tenses",
-            description: "Bulgarian verbs conjugate for person and number.\nThe present tense expresses ongoing actions (Аз уча български – I study Bulgarian).\nFuture tense uses the particle ще and the present tense of the verb (Аз ще уча български – I will study Bulgarian).",
-            examples: [
-                "Аз уча български. – I study Bulgarian.",
-                "Аз ще уча български. – I will study Bulgarian."
-            ],
-            level: "A1"
-        ),
-        // A2 grammar topics
-        GrammarTopic(
-            title: "Past Tenses",
-            description: "For A2 learners it's useful to distinguish between the past aorist and the past imperfect.\nThe past aorist describes completed actions (Аз учих български – I studied Bulgarian), while the past imperfect describes continuous or habitual past actions (Аз учех български – I was studying Bulgarian).",
-            examples: [
-                "Аз учих български. – I studied Bulgarian.",
-                "Аз учех български. – I was studying Bulgarian."
-            ],
-            level: "A2"
-        ),
-        GrammarTopic(
-            title: "Quantifiers and Numbers",
-            description: "At level A2 you'll encounter quantifiers and numbers more frequently.\nThe words много (many/much), малко (few/little), всички (all), няколко (several) and никой (none) help quantify nouns.\nBulgarian numbers one through ten are: едно, две, три, четири, пет, шест, седем, осем, девет, десет.",
-            examples: [
-                "Имам много книги. – I have many books.",
-                "Имаме няколко стола. – We have several chairs."
-            ],
-            level: "A2"
-        ),
-        GrammarTopic(
-            title: "Time Expressions",
-            description: "Talking about time requires vocabulary for days and parts of the day.\nThe days of the week are понеделник, вторник, сряда, четвъртък, петък, събота and неделя.\nParts of the day include сутрин (morning), обед (noon), следобед (afternoon), вечер (evening) and нощ (night).",
-            examples: [
-                "Срещаме се във вторник сутрин. – We meet on Tuesday morning.",
-                "Работя всеки ден следобед. – I work every afternoon."
-            ],
-            level: "A2"
-        ),
-        GrammarTopic(
-            title: "Food and Shopping Vocabulary",
-            description: "Food and shopping conversations are frequent at A2.\nLearn common nouns for food (хляб – bread, мляко – milk, сирене – cheese) and verbs for shopping (купувам – to buy, продавам – to sell, пазарувам – to shop).\nUnderstanding basic currency words like лев (the Bulgarian currency) and евро (euro) is also helpful.",
-            examples: [
-                "Купувам хляб от магазина. – I buy bread from the shop.",
-                "Колко струва това? – How much does this cost?"
-            ],
-            level: "A2"
-        ),
-        GrammarTopic(
-            title: "Travel and Directions",
-            description: "At A2 you may need to ask for directions or discuss travel.\nKey nouns include автобус (bus), влак (train), самолет (airplane), такси (taxi), гара (train station) and летище (airport).\nThe noun билет means 'ticket', and карта means 'map'.",
-            examples: [
-                "Къде е гарата? – Where is the train station?",
-                "Имам билет за автобуса. – I have a ticket for the bus."
-            ],
-            level: "A2"
-        )
-    ]
+    static let grammarTopics: [GrammarTopic] = GrammarData.topics
 }

--- a/DirectionToggle.swift
+++ b/DirectionToggle.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+/// A button that toggles the learning direction and updates the UI instantly.
+struct DirectionToggle: View {
+    @AppStorage("learningDirection") private var learningDirection: LearningDirection = .bulgarianToGerman
+
+    var body: some View {
+        Button(action: {
+            learningDirection = learningDirection == .bulgarianToGerman ? .germanToBulgarian : .bulgarianToGerman
+        }) {
+            Text(learningDirection.toggleLabel)
+                .font(.caption)
+                .padding(6)
+                .background(Color.blue.opacity(0.1))
+                .cornerRadius(6)
+        }
+        .buttonStyle(PlainButtonStyle())
+        .accessibilityLabel(learningDirection.toggleAccessibilityLabel)
+    }
+}

--- a/GrammarData.swift
+++ b/GrammarData.swift
@@ -1,0 +1,191 @@
+import Foundation
+
+/// Stores bilingual grammar topics used by the app.  Each topic contains
+/// Bulgarian and German text so that explanations can be shown in the
+/// learner's native language.
+struct GrammarData {
+    static let topics: [GrammarTopic] = [
+        GrammarTopic(
+            titleBG: "Ред на думите",
+            titleDE: "Wortstellung",
+            descriptionBG: "Българският словоред е гъвкав заради съгласуването между подлог и сказуемо. Неутралният ред е S + V + O + A (подлог, сказуемо, пряко допълнение, обстоятелствено пояснение), но са възможни и други варианти като A + S + V + O или O + S + V + A. Словоредът се променя за акцент без промяна на основния смисъл.",
+            descriptionDE: "Die bulgarische Wortstellung ist dank der Kongruenz zwischen Subjekt und Verb flexibel. Das neutrale Muster ist S + V + O + A (Subjekt, Verb, Objekt, Adverbial), aber auch andere Reihenfolgen wie A + S + V + O oder O + S + V + A sind möglich. Man verändert die Stellung, um Teile des Satzes zu betonen, ohne die Grundbedeutung zu ändern.",
+            examplesBG: [
+                "Той видя момичето в далечината. – Неутрален ред.",
+                "В далечината той видя момичето. – Акцент върху обстоятелството.",
+                "Момичето той видя в далечината. – Акцент върху обекта."
+            ],
+            examplesDE: [
+                "Той видя момичето в далечината. – Er sah das Mädchen in der Ferne.",
+                "В далечината той видя момичето. – In der Ferne sah er das Mädchen.",
+                "Момичето той видя в далечината. – Das Mädchen sah er in der Ferne."
+            ],
+            level: "A1"
+        ),
+        GrammarTopic(
+            titleBG: "Род на съществителните",
+            titleDE: "Genus der Substantive",
+            descriptionBG: "Българските съществителни имена имат три рода: мъжки, женски и среден. Мъжките често завършват на съгласна (мъж, син). Женските обикновено завършват на –а/–я (жена, ябълка). Средният род завършва на –е/–о (море, месо). Има изключения като баща (мъжки род с –а) или любов (женски род със съгласна).",
+            descriptionDE: "Bulgarische Substantive haben drei grammatische Geschlechter: maskulin, feminin und neutrum. Maskuline Nomen enden meist auf einen Konsonanten (мъж – Mann, син – Sohn). Feminine enden oft auf –а/–я (жена – Frau, ябълка – Apfel). Neutra enden typischerweise auf –е/–о (море – Meer, месо – Fleisch). Ausnahmen sind etwa баща (Maskulinum mit –a) oder любов (Femininum mit Konsonant).",
+            examplesBG: [
+                "мъж – мъжки род",
+                "жена – женски род",
+                "море – среден род",
+                "баща – мъжки род с –а",
+                "любов – женски род със съгласна"
+            ],
+            examplesDE: [
+                "мъж – Mann (Maskulinum)",
+                "жена – Frau (Femininum)",
+                "море – Meer (Neutrum)",
+                "баща – Vater (Maskulinum mit –a)",
+                "любов – Liebe (Femininum mit Konsonant)"
+            ],
+            level: "A1"
+        ),
+        GrammarTopic(
+            titleBG: "Единствено и множествено число",
+            titleDE: "Singular und Plural",
+            descriptionBG: "Съществителните имена имат единствено и множествено число. Мъжките образуват множествено с –и, –е или –ове (стол – столове). Женските заменят –а/–я с –и (жена – жени). Средният род взема –а или –ета (море – морета). Съществува историческа двойствена форма за някои мъжки думи (два стола).",
+            descriptionDE: "Bulgarische Nomen stehen im Singular oder Plural. Maskulina bilden den Plural mit Endungen wie –и, –е oder –ове (стол – столове). Feminina ersetzen –а/–я durch –и (жена – жени). Neutra erhalten –а oder –ета (море – морета). Eine historische Dualform überlebt bei einigen unbelebten Maskulina (два стола).",
+            examplesBG: [
+                "стол – столове",
+                "жена – жени",
+                "море – морета",
+                "два стола – двойствено число"
+            ],
+            examplesDE: [
+                "стол – stolove (Stuhl – Stühle)",
+                "жена – jeni (Frau – Frauen)",
+                "море – moreta (Meer – Meere)",
+                "два стола – zwei Stühle (Dual)"
+            ],
+            level: "A1"
+        ),
+        GrammarTopic(
+            titleBG: "Определителен член",
+            titleDE: "Bestimmter Artikel",
+            descriptionBG: "Определителният член в българския се поставя в края на думата. Мъжки род получава –ът/–ят (студент – студентът), женски –та (вода – водата), среден –то (село – селото). При множествено число се използва –те за мъжки и женски и –та за среден род.",
+            descriptionDE: "Der bulgarische bestimmte Artikel steht am Wortende. Maskuline Nomen nehmen –ът/–ят (студент – студентът), feminine –та (вода – водата) und neutrale –то (село – селото). Im Plural lautet der Artikel –те für Maskulina und Feminina bzw. –та für Neutra.",
+            examplesBG: [
+                "студент – студентът",
+                "вода – водата",
+                "село – селото",
+                "мъже – мъжете"
+            ],
+            examplesDE: [
+                "студент – студентът (der Student)",
+                "вода – водата (das Wasser)",
+                "село – селото (das Dorf)",
+                "мъже – мъжете (die Männer)"
+            ],
+            level: "A1"
+        ),
+        GrammarTopic(
+            titleBG: "Местоимения и падежи",
+            titleDE: "Pronomen und Fälle",
+            descriptionBG: "Падежите в българския се срещат главно при личните местоимения. Има три падежа: именителен (аз, ти, той, тя, то, ние, вие, те), винителен (ме, те, го, я, го, ни, ви, ги) и дателен (ми, ти, му, ѝ, му, ни, ви, им). Именителният се използва за подлог, винителният за пряко допълнение, а дателният за непряко.",
+            descriptionDE: "Fälle im Bulgarischen existieren vor allem bei den Personalpronomen. Es gibt drei: Nominativ (аз, ти, той, тя, то, ние, вие, те), Akkusativ (ме, те, го, я, го, ни, ви, ги) und Dativ (ми, ти, му, ѝ, му, ни, ви, им). Der Nominativ dient dem Subjekt, der Akkusativ dem direkten Objekt und der Dativ dem indirekten Objekt.",
+            examplesBG: [
+                "Аз го попитах как се чувства. – 'го' винителен.",
+                "Аз му дадох моята книга. – 'му' дателен."
+            ],
+            examplesDE: [
+                "Аз го попитах как се чувства. – Ich fragte ihn, wie er sich fühlt. (го – Akkusativ)",
+                "Аз му дадох моята книга. – Ich gab ihm mein Buch. (му – Dativ)"
+            ],
+            level: "A1"
+        ),
+        GrammarTopic(
+            titleBG: "Сегашно и бъдеще време",
+            titleDE: "Präsens und Futur",
+            descriptionBG: "Българските глаголи се спреждат по лице и число. Сегашното време изразява действащи действия (Аз уча български). Бъдещето време използва частицата ще и сегашно време на глагола (Аз ще уча български).",
+            descriptionDE: "Bulgarische Verben konjugieren nach Person und Zahl. Das Präsens beschreibt laufende Handlungen (Аз уча български – Ich lerne Bulgarisch). Das Futur wird mit der Partikel ще und dem Präsens des Verbs gebildet (Аз ще уча български – Ich werde Bulgarisch lernen).",
+            examplesBG: [
+                "Аз уча български.",
+                "Аз ще уча български."
+            ],
+            examplesDE: [
+                "Аз уча български. – Ich lerne Bulgarisch.",
+                "Аз ще уча български. – Ich werde Bulgarisch lernen."
+            ],
+            level: "A1"
+        ),
+        // A2 topics
+        GrammarTopic(
+            titleBG: "Минали времена",
+            titleDE: "Vergangenheitszeiten",
+            descriptionBG: "На ниво А2 е важно да се различават миналото свършено (аорист) и миналото несвършено (имперфект). Аористът описва завършени действия (Аз учих български), а имперфектът – продължителни или обичайни действия в миналото (Аз учех български).",
+            descriptionDE: "Für Lernende auf A2 ist es hilfreich, zwischen dem bulgarischen Aorist und Imperfekt zu unterscheiden. Der Aorist beschreibt abgeschlossene Handlungen (Аз учих български – Ich lernte Bulgarisch), während der Imperfekt kontinuierliche oder gewohnheitsmäßige Vergangenheitsaktionen ausdrückt (Аз учех български – Ich lernte gerade Bulgarisch).",
+            examplesBG: [
+                "Аз учих български.",
+                "Аз учех български."
+            ],
+            examplesDE: [
+                "Аз учих български. – Ich lernte Bulgarisch.",
+                "Аз учех български. – Ich lernte gerade Bulgarisch."
+            ],
+            level: "A2"
+        ),
+        GrammarTopic(
+            titleBG: "Количествени думи и числа",
+            titleDE: "Quantoren und Zahlen",
+            descriptionBG: "На А2 ще срещнете по-често количествени думи като много, малко, всички, няколко, никой. Числата от едно до десет са: едно, две, три, четири, пет, шест, седем, осем, девет, десет.",
+            descriptionDE: "Auf Niveau A2 begegnen Ihnen häufiger Quantoren und Zahlen. Wörter wie много (viel), малко (wenig), всички (alle), няколко (einige) und никой (keiner) quantifizieren Nomen. Die bulgarischen Zahlen eins bis zehn lauten: едно, две, три, четири, пет, шест, седем, осем, девет, десет.",
+            examplesBG: [
+                "Имам много книги.",
+                "Имаме няколко стола."
+            ],
+            examplesDE: [
+                "Имам много книги. – Ich habe viele Bücher.",
+                "Имаме няколко стола. – Wir haben einige Stühle."
+            ],
+            level: "A2"
+        ),
+        GrammarTopic(
+            titleBG: "Изрази за време",
+            titleDE: "Zeitangaben",
+            descriptionBG: "За да говорите за време, трябва думи за дните от седмицата и частите на деня. Дните са понеделник, вторник, сряда, четвъртък, петък, събота, неделя. Частите на деня са сутрин, обед, следобед, вечер, нощ.",
+            descriptionDE: "Um über Zeit zu sprechen, benötigt man Wörter für Wochentage und Tageszeiten. Die Wochentage sind понеделник, вторник, сряда, четвъртък, петък, събота, неделя. Tageszeiten sind сутрин (Morgen), обед (Mittag), следобед (Nachmittag), вечер (Abend) und нощ (Nacht).",
+            examplesBG: [
+                "Срещаме се във вторник сутрин.",
+                "Работя всеки ден следобед."
+            ],
+            examplesDE: [
+                "Срещаме се във вторник сутрин. – Wir treffen uns am Dienstagmorgen.",
+                "Работя всеки ден следобед. – Ich arbeite jeden Nachmittag."
+            ],
+            level: "A2"
+        ),
+        GrammarTopic(
+            titleBG: "Храна и пазаруване",
+            titleDE: "Essen und Einkaufen",
+            descriptionBG: "На А2 често ще говорите за храна и пазаруване. Научете съществителни като хляб, мляко, сирене и глаголи като купувам, продавам, пазарувам. Полезно е да знаете думи за валута като лев и евро.",
+            descriptionDE: "Auf A2 spricht man häufig über Essen und Einkaufen. Lernen Sie Nomen wie хляб (Brot), мляко (Milch), сирене (Käse) sowie Verben wie купувам (kaufen), продавам (verkaufen), пазарувам (einkaufen). Hilfreich sind auch Wörter für Währungen wie лев und евро.",
+            examplesBG: [
+                "Купувам хляб от магазина.",
+                "Колко струва това?"
+            ],
+            examplesDE: [
+                "Купувам хляб от магазина. – Ich kaufe Brot im Laden.",
+                "Колко струва това? – Wie viel kostet das?"
+            ],
+            level: "A2"
+        ),
+        GrammarTopic(
+            titleBG: "Пътуване и посоки",
+            titleDE: "Reisen und Richtungen",
+            descriptionBG: "На А2 може да се наложи да питате за посоки или да говорите за пътуване. Важни думи са автобус, влак, самолет, такси, гара и летище. Думата билет означава билет, а карта – карта.",
+            descriptionDE: "Auf A2 müssen Sie möglicherweise nach dem Weg fragen oder über Reisen sprechen. Wichtige Wörter sind автобус (Bus), влак (Zug), самолет (Flugzeug), такси (Taxi), гара (Bahnhof) und летище (Flughafen). билет bedeutet 'Ticket' und карта 'Karte'.",
+            examplesBG: [
+                "Къде е гарата?",
+                "Имам билет за автобуса."
+            ],
+            examplesDE: [
+                "Къде е гарата? – Wo ist der Bahnhof?",
+                "Имам билет за автобуса. – Ich habe ein Ticket für den Bus."
+            ],
+            level: "A2"
+        )
+    ]
+}

--- a/GrammarDetailView.swift
+++ b/GrammarDetailView.swift
@@ -5,20 +5,22 @@ import SwiftUI
 /// scroll view ensures content is readable on smaller screens.
 struct GrammarDetailView: View {
     let topic: GrammarTopic
+    @AppStorage("learningDirection") private var learningDirection: LearningDirection = .bulgarianToGerman
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
-                Text(topic.title)
+                Text(topic.title(for: learningDirection))
                     .font(.title)
                     .bold()
-                Text(topic.description)
+                Text(topic.description(for: learningDirection))
                     .font(.body)
-                if !topic.examples.isEmpty {
-                    Text("Examples:")
+                let examples = topic.examples(for: learningDirection)
+                if !examples.isEmpty {
+                    Text(learningDirection == .bulgarianToGerman ? "Beispiele:" : "Примери:")
                         .font(.headline)
                         .padding(.top)
-                    ForEach(topic.examples, id: \.self) { example in
+                    ForEach(examples, id: \.self) { example in
                         Text("• \(example)")
                     }
                 }
@@ -26,14 +28,28 @@ struct GrammarDetailView: View {
             }
             .padding()
         }
-        .navigationTitle(topic.title)
+        .navigationTitle(topic.title(for: learningDirection))
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                DirectionToggle()
+            }
+        }
     }
 }
 
 struct GrammarDetailView_Previews: PreviewProvider {
     static var previews: some View {
-        NavigationView {
-            GrammarDetailView(topic: GrammarTopic(title: "Gender of Nouns", description: "Example description", examples: ["мъж – man"], level: "A1"))
+        let sample = GrammarTopic(
+            titleBG: "Род на съществителните",
+            titleDE: "Genus der Substantive",
+            descriptionBG: "Примерно описание",
+            descriptionDE: "Beispielbeschreibung",
+            examplesBG: ["мъж – мъжки род"],
+            examplesDE: ["мъж – Mann (Maskulinum)"],
+            level: "A1"
+        )
+        return NavigationView {
+            GrammarDetailView(topic: sample)
         }
     }
 }

--- a/GrammarListView.swift
+++ b/GrammarListView.swift
@@ -5,20 +5,26 @@ import SwiftUI
 /// `GrammarDetailView` which contains the full explanation and examples.
 struct GrammarListView: View {
     let level: String
+    @AppStorage("learningDirection") private var learningDirection: LearningDirection = .bulgarianToGerman
     private var topics: [GrammarTopic] {
         DataStore.grammarTopics.filter { $0.level == level }
-            .sorted { $0.title < $1.title }
+            .sorted { $0.title(for: learningDirection) < $1.title(for: learningDirection) }
     }
 
     var body: some View {
         List {
             ForEach(topics) { topic in
                 NavigationLink(destination: GrammarDetailView(topic: topic)) {
-                    Text(topic.title)
+                    Text(topic.title(for: learningDirection))
                 }
             }
         }
-        .navigationTitle("\(level) Grammar")
+        .navigationTitle("\(level) \(learningDirection == .bulgarianToGerman ? "Grammatik" : "Граматика")")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                DirectionToggle()
+            }
+        }
     }
 }
 

--- a/Models.swift
+++ b/Models.swift
@@ -1,9 +1,52 @@
 import Foundation
 
-/// A single vocabulary entry consisting of the Bulgarian word, its English
-/// translation, the part of speech (noun, verb, adjective, etc.) and the
-/// associated CEFR level (A1 or A2).  A unique identifier is generated
-/// automatically so that the objects can be used in SwiftUI lists.
+/// The direction in which a learner studies vocabulary.
+///
+/// * `.bulgarianToGerman` – German speakers learn Bulgarian words with
+///   German explanations.
+/// * `.germanToBulgarian` – Bulgarian speakers learn German words with
+///   Bulgarian explanations.
+enum LearningDirection: String, CaseIterable, Identifiable {
+    case bulgarianToGerman = "bgToDe"
+    case germanToBulgarian = "deToBg"
+
+    var id: String { rawValue }
+
+    /// Short text used on the toggle button (e.g. "BG→DE").
+    var toggleLabel: String {
+        self == .bulgarianToGerman ? "BG→DE" : "DE→BG"
+    }
+
+    /// Accessibility label describing the action of the toggle.
+    var toggleAccessibilityLabel: String {
+        self == .bulgarianToGerman ? "Switch to German to Bulgarian" : "Превключи към български към немски"
+    }
+
+    /// Label for the "all" filter in lists.
+    var allFilterLabel: String {
+        self == .bulgarianToGerman ? "Alle" : "Всички"
+    }
+
+    /// Message shown when search results are empty.
+    var noResultsText: String {
+        self == .bulgarianToGerman ? "Keine Ergebnisse." : "Няма резултати."
+    }
+
+    /// Text for clearing the search field.
+    var clearSearchLabel: String {
+        self == .bulgarianToGerman ? "Suche löschen" : "Изчисти търсенето"
+    }
+
+    /// Accessibility text for playing pronunciation of a given word.
+    func playPronunciationLabel(for word: String) -> String {
+        self == .bulgarianToGerman ? "Aussprache für \(word) abspielen" : "Пусни произношението на \(word)"
+    }
+}
+
+/// A single vocabulary entry consisting of the Bulgarian word, its German
+/// translation, the part of speech and the associated CEFR level. A unique
+/// identifier is generated automatically so that the objects can be used in
+/// SwiftUI lists.
 struct VocabularyItem: Identifiable {
     let id = UUID()
     let word: String
@@ -11,16 +54,68 @@ struct VocabularyItem: Identifiable {
     let type: String
     let level: String
     let notes: String?
-    
-    /// Audio settings for pronunciation
-    var audioSettings: AudioSettings {
-        AudioSettings(
-            text: word,
-            language: "bg-BG", // Bulgarian language code
-            rate: UserDefaults.standard.float(forKey: "speechRate"),
-            volume: UserDefaults.standard.float(forKey: "speechVolume")
-        )
+
+    /// Return the word shown to the user depending on the learning
+    /// direction. German learners see the Bulgarian word, Bulgarian
+    /// learners see the German word.
+    func displayedWord(for direction: LearningDirection) -> String {
+        direction == .bulgarianToGerman ? word : translation
     }
+
+    /// Return the translation shown to the user depending on the learning
+    /// direction.
+    func displayedTranslation(for direction: LearningDirection) -> String {
+        direction == .bulgarianToGerman ? translation : word
+    }
+
+    /// Localise the part of speech for the selected learning direction.
+    func displayedType(for direction: LearningDirection) -> String {
+        if direction == .bulgarianToGerman {
+            return type
+        }
+        return VocabularyItem.typeMap[type] ?? type
+    }
+
+    /// Localise any notes for the selected learning direction.
+    func displayedNotes(for direction: LearningDirection) -> String? {
+        if direction == .bulgarianToGerman {
+            return notes
+        }
+        return VocabularyItem.bgNotesMap[word]
+    }
+
+    /// Return the appropriate language code for pronunciation depending on
+    /// the current direction.
+    func audioLanguage(for direction: LearningDirection) -> String {
+        direction == .bulgarianToGerman ? "bg-BG" : "de-DE"
+    }
+
+    /// Mapping between German and Bulgarian part‑of‑speech labels.
+    private static let typeMap: [String: String] = [
+        "Begrüßung": "Поздрав",
+        "Ausdruck": "Израз",
+        "Substantiv": "Съществително",
+        "Verb": "Глагол",
+        "Adjektiv": "Прилагателно",
+        "Adverb": "Наречие",
+        "Zahl": "Число",
+        "Quantor": "Квантор",
+        "Tag": "Ден",
+        "Natur": "Природа",
+        "Familie": "Семейство",
+        "Einkauf": "Пазаруване"
+    ]
+
+    /// Bulgarian translations for the explanatory notes keyed by the
+    /// Bulgarian word.
+    private static let bgNotesMap: [String: String] = [
+        "Здравей": "Думата \"Здравей\" произлиза от \"здрав\" и е пожелание за здраве.",
+        "Село": "\"Село\" означава малко населено място и е сродно с други славянски думи за селище.",
+        "Книга": "\"Книга\" идва от старославянски и първоначално е означавала свитък или подвързано произведение.",
+        "Вода": "\"Вода\" има същия индоевропейски корен като немската дума \"Wasser\".",
+        "Море": "\"Море\" означава море и е сродно на руското \"море\"; думата произхожда от праславянски корен.",
+        "Лев": "Българската валута \"лев\" е наречена на старото българско слово за \"лъв\" – национален символ."
+    ]
 }
 
 /// Audio settings for text-to-speech pronunciation
@@ -39,13 +134,27 @@ struct AudioSettings {
 }
 
 /// A grammar topic summarises a single concept such as gender or word order.
-/// Each topic has a title, a detailed description, a list of example
-/// sentences, and an associated level indicating when a learner is
-/// expected to encounter the topic.
+/// Text is provided in both Bulgarian and German so it can be shown to the
+/// learner depending on the selected learning direction.
 struct GrammarTopic: Identifiable {
     let id = UUID()
-    let title: String
-    let description: String
-    let examples: [String]
+    let titleBG: String
+    let titleDE: String
+    let descriptionBG: String
+    let descriptionDE: String
+    let examplesBG: [String]
+    let examplesDE: [String]
     let level: String
+
+    func title(for direction: LearningDirection) -> String {
+        direction == .bulgarianToGerman ? titleDE : titleBG
+    }
+
+    func description(for direction: LearningDirection) -> String {
+        direction == .bulgarianToGerman ? descriptionDE : descriptionBG
+    }
+
+    func examples(for direction: LearningDirection) -> [String] {
+        direction == .bulgarianToGerman ? examplesDE : examplesBG
+    }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -19,18 +19,21 @@ let package = Package(
         .executableTarget(
             name: "BulgarianVocabularyApp",
             path: ".",
+            exclude: ["README.md"],
             sources: [
                 "BulgarianVocabularyApp.swift",
-                "ContentView.swift", 
+                "ContentView.swift",
                 "DataStore.swift",
                 "Models.swift",
+                "GrammarData.swift",
                 "VocabularyListView.swift",
                 "VocabularyDetailView.swift",
                 "GrammarListView.swift",
                 "GrammarDetailView.swift",
+                "DirectionToggle.swift",
                 "AudioManager.swift",
                 "SettingsView.swift"
             ]
         )
     ]
-) 
+)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Bulgarian-German Learning App
 
-A SwiftUI-based iOS application for learning Bulgarian vocabulary and grammar with German translations.
+A SwiftUI-based iOS application for learning Bulgarian and German vocabulary and grammar.
 
 ## Features
 
-- **Vocabulary Learning**: Browse Bulgarian words organized by CEFR levels (A1 and A2)
-- **Grammar Topics**: Learn Bulgarian grammar concepts with detailed explanations
-- **German Translations**: All vocabulary items include German translations
+- **Vocabulary Learning**: Browse words organised by CEFR levels (A1 and A2)
+- **Grammar Topics**: Learn grammar concepts with detailed explanations
+- **Bilingual Mode**: Toggle between Bulgarian→German and German→Bulgarian learning directions on every screen
 - **Offline Learning**: Complete offline functionality with local data storage
 - **User-Friendly Interface**: Clean, intuitive SwiftUI interface
 

--- a/SettingsView.swift
+++ b/SettingsView.swift
@@ -4,45 +4,46 @@ import SwiftUI
 struct SettingsView: View {
     @StateObject private var audioManager = AudioManager()
     @Environment(\.presentationMode) var presentationMode
+    @AppStorage("learningDirection") private var learningDirection: LearningDirection = .bulgarianToGerman
     
     var body: some View {
         NavigationView {
             Form {
-                Section(header: Text("Audio Settings")) {
+                Section(header: Text(learningDirection == .bulgarianToGerman ? "Audioeinstellungen" : "Аудио настройки")) {
                     VStack(alignment: .leading, spacing: 8) {
                         HStack {
-                            Text("Speech Rate")
+                            Text(learningDirection == .bulgarianToGerman ? "Sprechgeschwindigkeit" : "Скорост на речта")
                             Spacer()
                             Text("\(Int(audioManager.speechRate * 100))%")
                                 .foregroundColor(.secondary)
                         }
-                        
+
                         Slider(value: $audioManager.speechRate, in: 0.1...1.0, step: 0.1)
                             .accentColor(.blue)
-                        Text("Adjust how fast the words are spoken.")
+                        Text(learningDirection == .bulgarianToGerman ? "Stellen Sie ein, wie schnell die Wörter gesprochen werden." : "Настройте колко бързо се произнасят думите.")
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }
-                    
+
                     VStack(alignment: .leading, spacing: 8) {
                         HStack {
-                            Text("Volume")
+                            Text(learningDirection == .bulgarianToGerman ? "Lautstärke" : "Сила на звука")
                             Spacer()
                             Text("\(Int(audioManager.speechVolume * 100))%")
                                 .foregroundColor(.secondary)
                         }
-                        
+
                         Slider(value: $audioManager.speechVolume, in: 0.0...1.0, step: 0.1)
                             .accentColor(.blue)
-                        Text("Adjust the pronunciation volume.")
+                        Text(learningDirection == .bulgarianToGerman ? "Stellen Sie die Lautstärke der Aussprache ein." : "Настройте силата на произношението.")
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }
                 }
-                
-                Section(header: Text("Test Audio")) {
+
+                Section(header: Text(learningDirection == .bulgarianToGerman ? "Audio testen" : "Тествай аудио")) {
                     HStack {
-                        Text("Test pronunciation")
+                        Text(learningDirection == .bulgarianToGerman ? "Aussprache testen" : "Тествай произношението")
                         Spacer()
                         Button(action: {
                             audioManager.speak("Здравей", language: "bg-BG")
@@ -53,29 +54,40 @@ struct SettingsView: View {
                         }
                     }
                 }
-                
-                Section(header: Text("About")) {
+
+                Section(header: Text(learningDirection == .bulgarianToGerman ? "Über die App" : "Относно приложението")) {
                     VStack(alignment: .leading, spacing: 8) {
-                        Text("Bulgarian-German Learning App")
+                        Text(learningDirection == .bulgarianToGerman ? "Bulgarisch-Deutsche Lern-App" : "Българо-немско учебно приложение")
                             .font(.headline)
                         Text("Version 1.0")
                             .font(.subheadline)
                             .foregroundColor(.secondary)
-                        Text("Learn Bulgarian vocabulary with German translations and audio pronunciation.")
+                        Text(learningDirection == .bulgarianToGerman ? "Lerne bulgarischen Wortschatz mit deutschen Übersetzungen und Audioaussprache." : "Учи немски думи с български преводи и произношение.")
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }
                     .padding(.vertical, 4)
                 }
-            }
-            .navigationTitle("Settings")
-            .toolbar {
-                ToolbarItem(placement: .primaryAction) {
-                    Button("Done") {
-                        presentationMode.wrappedValue.dismiss()
+                // Language direction selection
+                Section(header: Text(learningDirection == .bulgarianToGerman ? "Lernrichtung" : "Посока на обучение")) {
+                    Picker("", selection: $learningDirection) {
+                        Text("Bulgarisch ➜ Deutsch").tag(LearningDirection.bulgarianToGerman)
+                        Text("Deutsch ➜ Bulgarisch").tag(LearningDirection.germanToBulgarian)
                     }
+                    .pickerStyle(SegmentedPickerStyle())
                 }
             }
+            .navigationTitle(learningDirection == .bulgarianToGerman ? "Einstellungen" : "Настройки")
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        DirectionToggle()
+                    }
+                    ToolbarItem(placement: .primaryAction) {
+                        Button(learningDirection == .bulgarianToGerman ? "Fertig" : "Готово") {
+                            presentationMode.wrappedValue.dismiss()
+                        }
+                    }
+                }
         }
         .onDisappear {
             audioManager.stop()

--- a/VocabularyDetailView.swift
+++ b/VocabularyDetailView.swift
@@ -1,45 +1,47 @@
 import SwiftUI
 
-/// Shows detailed information about a single vocabulary item.  Besides the
-/// Bulgarian word and its translation, this view displays the part of
-/// speech and any additional notes.  A spacer pushes content to the top
-/// when there is little information.
+/// Shows detailed information about a single vocabulary item.  Depending on
+/// the current learning direction, the view presents the headword with its
+/// translation, the part of speech and any additional notes.  A spacer pushes
+/// content to the top when there is little information.
 struct VocabularyDetailView: View {
     let item: VocabularyItem
     @StateObject private var audioManager = AudioManager()
+    @AppStorage("learningDirection") private var learningDirection: LearningDirection = .bulgarianToGerman
     
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
-                // Bulgarian word with audio button
+                // Word with audio button
                 HStack {
-                    Text(item.word)
+                    let baseWord = item.displayedWord(for: learningDirection)
+                    Text(baseWord)
                         .font(.largeTitle)
                         .bold()
-                    
+
                     Spacer()
-                    
+
                     Button(action: {
-                        if audioManager.isSpeaking && audioManager.currentText == item.word {
+                        if audioManager.isSpeaking && audioManager.currentText == baseWord {
                             audioManager.stop()
                         } else {
-                            audioManager.speak(item.word, language: "bg-BG")
+                            audioManager.speak(baseWord, language: item.audioLanguage(for: learningDirection))
                         }
                     }) {
-                        Image(systemName: audioManager.isSpeaking && audioManager.currentText == item.word ? "stop.circle.fill" : "play.circle.fill")
+                        Image(systemName: audioManager.isSpeaking && audioManager.currentText == baseWord ? "stop.circle.fill" : "play.circle.fill")
                             .font(.title)
                             .foregroundColor(.blue)
                     }
-                    .accessibilityLabel("Play pronunciation for \(item.word)")
+                    .accessibilityLabel(learningDirection.playPronunciationLabel(for: baseWord))
                 }
                 Divider()
-                // German translation
-                Text(item.translation)
+                // Translation
+                Text(item.displayedTranslation(for: learningDirection))
                     .font(.title2)
                     .foregroundColor(.primary)
                 Divider()
                 // Part of speech
-                Text("Part of speech: \(item.type)")
+                Text((learningDirection == .bulgarianToGerman ? "Wortart: " : "Част на речта: ") + item.displayedType(for: learningDirection))
                     .font(.subheadline)
                     .foregroundColor(.secondary)
                     .padding(.horizontal, 12)
@@ -48,12 +50,12 @@ struct VocabularyDetailView: View {
                     .cornerRadius(8)
                 Divider()
                 // Notes section
-                if let notes = item.notes, !notes.isEmpty {
+                if let notes = item.displayedNotes(for: learningDirection), !notes.isEmpty {
                     VStack(alignment: .leading, spacing: 8) {
-                        Text("Notes:")
+                        Text(learningDirection == .bulgarianToGerman ? "Notizen:" : "Бележки:")
                             .font(.headline)
                             .foregroundColor(.primary)
-                        
+
                         Text(notes)
                             .font(.body)
                             .foregroundColor(.secondary)
@@ -67,9 +69,14 @@ struct VocabularyDetailView: View {
             }
             .padding()
         }
-        .navigationTitle(item.word)
+        .navigationTitle(item.displayedWord(for: learningDirection))
         .navigationBarBackButtonHidden(false)
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                DirectionToggle()
+            }
+        }
         .onDisappear {
             audioManager.stop()
         }

--- a/VocabularyListView.swift
+++ b/VocabularyListView.swift
@@ -1,18 +1,20 @@
 import SwiftUI
 
-/// Displays a list of vocabulary items for a given level.  Each row shows
-/// the Bulgarian word and its English translation.  Tapping on a row
-/// navigates to a detail view with more information.
+/// Displays a list of vocabulary items for a given level.  Each row adapts to
+/// the current learning direction, presenting the headword with its
+/// translation.  Tapping on a row navigates to a detail view with more
+/// information.
 struct VocabularyListView: View {
     let level: String
     @StateObject private var audioManager = AudioManager()
     @State private var searchText = ""
-    @State private var selectedType = "All"
+    @State private var selectedType = ""
+    @AppStorage("learningDirection") private var learningDirection: LearningDirection = .bulgarianToGerman
     
     // Filter the shared vocabulary items by level on initialisation
     private var items: [VocabularyItem] {
         DataStore.vocabularyItems.filter { $0.level == level }
-            .sorted { $0.word < $1.word }
+            .sorted { $0.displayedWord(for: learningDirection) < $1.displayedWord(for: learningDirection) }
     }
     
     // Filtered items based on search and type
@@ -21,13 +23,13 @@ struct VocabularyListView: View {
         
         if !searchText.isEmpty {
             filtered = filtered.filter { 
-                $0.word.localizedCaseInsensitiveContains(searchText) ||
-                $0.translation.localizedCaseInsensitiveContains(searchText)
+                $0.displayedWord(for: learningDirection).localizedCaseInsensitiveContains(searchText) ||
+                $0.displayedTranslation(for: learningDirection).localizedCaseInsensitiveContains(searchText)
             }
         }
         
-        if selectedType != "All" {
-            filtered = filtered.filter { $0.type == selectedType }
+        if selectedType != allFilterLabel {
+            filtered = filtered.filter { $0.displayedType(for: learningDirection) == selectedType }
         }
         
         return filtered
@@ -35,9 +37,11 @@ struct VocabularyListView: View {
     
     // Available types for filtering
     private var availableTypes: [String] {
-        let types = Set(items.map { $0.type })
-        return ["All"] + Array(types).sorted()
+        let types = Set(items.map { $0.displayedType(for: learningDirection) })
+        return [allFilterLabel] + Array(types).sorted()
     }
+
+    private var allFilterLabel: String { learningDirection.allFilterLabel }
 
     var body: some View {
         VStack {
@@ -47,7 +51,7 @@ struct VocabularyListView: View {
                 HStack {
                     Image(systemName: "magnifyingglass")
                         .foregroundColor(.gray)
-                    TextField("Search words...", text: $searchText)
+                    TextField(learningDirection == .bulgarianToGerman ? "Wörter suchen..." : "Търсене...", text: $searchText)
                         .textFieldStyle(RoundedBorderTextFieldStyle())
                     if !searchText.isEmpty {
                         Button(action: { searchText = "" }) {
@@ -55,7 +59,7 @@ struct VocabularyListView: View {
                                 .foregroundColor(.gray)
                         }
                         .buttonStyle(PlainButtonStyle())
-                        .accessibilityLabel("Clear search")
+                        .accessibilityLabel(learningDirection.clearSearchLabel)
                     }
                 }
                 .padding(6)
@@ -87,7 +91,7 @@ struct VocabularyListView: View {
             // Vocabulary list
             if filteredItems.isEmpty {
                 Spacer()
-                Text("No results found.")
+                Text(learningDirection.noResultsText)
                     .foregroundColor(.secondary)
                     .padding()
                 Spacer()
@@ -97,12 +101,12 @@ struct VocabularyListView: View {
                         NavigationLink(destination: VocabularyDetailView(item: item)) {
                             HStack {
                                 VStack(alignment: .leading, spacing: 4) {
-                                    Text(item.word)
+                                    Text(item.displayedWord(for: learningDirection))
                                         .font(.headline)
-                                    Text(item.translation)
+                                    Text(item.displayedTranslation(for: learningDirection))
                                         .font(.subheadline)
                                         .foregroundColor(.secondary)
-                                    Text(item.type)
+                                    Text(item.displayedType(for: learningDirection))
                                         .font(.caption)
                                         .foregroundColor(.blue)
                                         .padding(.horizontal, 6)
@@ -111,27 +115,36 @@ struct VocabularyListView: View {
                                         .cornerRadius(4)
                                 }
                                 Spacer()
-                                // Audio button
+                                let baseWord = item.displayedWord(for: learningDirection)
                                 Button(action: {
-                                    if audioManager.isSpeaking && audioManager.currentText == item.word {
+                                    if audioManager.isSpeaking && audioManager.currentText == baseWord {
                                         audioManager.stop()
                                     } else {
-                                        audioManager.speak(item.word, language: "bg-BG")
+                                        audioManager.speak(baseWord, language: item.audioLanguage(for: learningDirection))
                                     }
                                 }) {
-                                    Image(systemName: audioManager.isSpeaking && audioManager.currentText == item.word ? "stop.circle.fill" : "play.circle.fill")
+                                    Image(systemName: audioManager.isSpeaking && audioManager.currentText == baseWord ? "stop.circle.fill" : "play.circle.fill")
                                         .font(.title2)
                                         .foregroundColor(.blue)
                                 }
                                 .buttonStyle(PlainButtonStyle())
-                                .accessibilityLabel("Play pronunciation for \(item.word)")
+                                .accessibilityLabel(learningDirection.playPronunciationLabel(for: baseWord))
                             }
                         }
                     }
                 }
             }
         }
-        .navigationTitle("\(level) Vocabulary")
+        .navigationTitle("\(level) \(learningDirection == .bulgarianToGerman ? "Vokabeln" : "Лексика")")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                DirectionToggle()
+            }
+        }
+        .onAppear { selectedType = allFilterLabel }
+        .onChange(of: learningDirection) { _ in
+            selectedType = allFilterLabel
+        }
         .onDisappear {
             audioManager.stop()
         }


### PR DESCRIPTION
## Summary
- add reusable `DirectionToggle` button and wire it into the package
- show the toggle on ContentView, vocabulary and grammar screens, and settings
- automatically reset vocabulary filters on language switch and document the global toggle

## Testing
- `swift build` *(fails: no such module 'AVFoundation')*


------
https://chatgpt.com/codex/tasks/task_e_68927a40aca08320aa38f02f71befd91