### PR TITLE
Implement SM-2 spaced repetition

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::time::{Duration, SystemTime};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct VocabularyItem {
@@ -19,7 +20,59 @@ pub struct GrammarItem {
 
 pub mod data;
 
-// Placeholder for spaced repetition logic
-pub fn next_review_time(_correct: bool) -> Option<std::time::SystemTime> {
-    None
+/// State used by the SM-2 spaced repetition algorithm.
+///
+/// * `interval` - the current interval in days
+/// * `ease_factor` - ease factor used to grow the interval
+/// * `repetitions` - number of consecutive correct reviews
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReviewState {
+    pub interval: u32,
+    pub ease_factor: f64,
+    pub repetitions: u32,
+}
+
+impl Default for ReviewState {
+    fn default() -> Self {
+        Self {
+            interval: 0,
+            ease_factor: 2.5,
+            repetitions: 0,
+        }
+    }
+}
+
+/// Calculate the next review time using the SM-2 algorithm.
+///
+/// The `correct` flag represents whether the user answered the item
+/// correctly. The provided `state` is updated in place and the
+/// `SystemTime` of the next review is returned.
+pub fn next_review_time(correct: bool, state: &mut ReviewState) -> SystemTime {
+    // Map the bool to a SM-2 quality response. Correct answers are treated as
+    // quality 5, wrong answers as quality 2 so that the card is considered
+    // failed and repetitions reset.
+    let quality: u32 = if correct { 5 } else { 2 };
+
+    if quality < 3 {
+        state.repetitions = 0;
+        state.interval = 1;
+    } else {
+        state.repetitions += 1;
+        match state.repetitions {
+            1 => state.interval = 1,
+            2 => state.interval = 6,
+            _ => {
+                state.interval = (state.interval as f64 * state.ease_factor).round() as u32;
+            }
+        }
+    }
+
+    // Update ease factor according to SM-2 formula.
+    let q = quality as f64;
+    state.ease_factor += 0.1 - (5.0 - q) * (0.08 + (5.0 - q) * 0.02);
+    if state.ease_factor < 1.3 {
+        state.ease_factor = 1.3;
+    }
+
+    SystemTime::now() + Duration::from_secs(state.interval as u64 * 60 * 60 * 24)
 }

--- a/lib/tests/spaced_rep.rs
+++ b/lib/tests/spaced_rep.rs
@@ -1,0 +1,45 @@
+use bglg_app_lib::{next_review_time, ReviewState};
+use std::time::{Duration, SystemTime};
+
+fn approx_eq(a: f64, b: f64) {
+    assert!((a - b).abs() < 1e-6, "{} != {}", a, b);
+}
+
+#[test]
+fn sm2_correct_progression() {
+    let mut state = ReviewState::default();
+
+    // First correct answer
+    let now = SystemTime::now();
+    let next = next_review_time(true, &mut state);
+    assert_eq!(state.repetitions, 1);
+    assert_eq!(state.interval, 1);
+    approx_eq(state.ease_factor, 2.6);
+    let diff = next.duration_since(now).unwrap();
+    assert!(diff >= Duration::from_secs(86400));
+
+    // Second correct answer
+    next_review_time(true, &mut state);
+    assert_eq!(state.repetitions, 2);
+    assert_eq!(state.interval, 6);
+    approx_eq(state.ease_factor, 2.7);
+
+    // Third correct answer
+    next_review_time(true, &mut state);
+    assert_eq!(state.repetitions, 3);
+    assert_eq!(state.interval, 16); // round(6 * 2.7)
+    approx_eq(state.ease_factor, 2.8);
+}
+
+#[test]
+fn sm2_incorrect_resets() {
+    let mut state = ReviewState::default();
+    next_review_time(true, &mut state);
+    next_review_time(true, &mut state);
+
+    // Incorrect answer should reset repetitions and interval
+    next_review_time(false, &mut state);
+    assert_eq!(state.repetitions, 0);
+    assert_eq!(state.interval, 1);
+    approx_eq(state.ease_factor, 2.38);
+}


### PR DESCRIPTION
## Summary
- add serializable `ReviewState` to track study progress
- implement SM-2 based `next_review_time` scheduler
- test spaced repetition transitions

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6893910eca048320acf35855096f637d