### PR TITLE
Fix Hugo Build Error in Index Template

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -126,7 +126,9 @@ defaultContentLanguageInSubdir = false
 # Site parameters
 [params]
   description = 'Learn Bulgarian and German with spaced repetition'
-  author = 'Bulgarian-German Learning App'
+
+  [params.author]
+    name = 'Bulgarian-German Learning App'
   
   # Language learning specific
   enablePWA = true

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -14,7 +14,7 @@
                     <span class="stat-label">Речникови единици / Wortschatz-Einträge</span>
                 </div>
                 <div class="stat-item">
-                    <span class="stat-number">{{ len .Site.Data.grammar }}</span>
+                    <span class="stat-number">{{ len (index .Site.Data "cultural-grammar") }}</span>
                     <span class="stat-label">Граматични правила / Grammatikregeln</span>
                 </div>
                 <div class="stat-item">


### PR DESCRIPTION
Fixed two issues preventing Hugo build from succeeding:

1. Template Error (layouts/index.html:17):
   - Changed .Site.Data.grammar to index .Site.Data "cultural-grammar"
   - The data file is named cultural-grammar.json (with hyphen), which requires index notation to access in Hugo templates

2. Deprecation Warning (hugo.toml):
   - Updated params.author to params.author.name structure
   - This aligns with Hugo's recommended configuration format

These changes resolve the build error that was blocking the CI/CD pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)