### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/layouts/_shortcodes/vocab-search.html
+++ b/layouts/_shortcodes/vocab-search.html
@@ -182,6 +182,16 @@ function performSearch() {
   }, 300);
 }
 
+// Escape HTML for untrusted values
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 function displayResults(results, query, searchTime) {
   const resultsContainer = document.getElementById('search-results');
   const noResults = document.getElementById('no-results');
@@ -215,16 +225,22 @@ function displayResults(results, query, searchTime) {
     return;
   }
   
+  }
+  
   // Render results using the vocab-card shortcode structure
   resultsContainer.innerHTML = results.map(item => `
-    <div class="vocab-card search-result" data-word="${item.word.toLowerCase()}" data-translation="${item.translation.toLowerCase()}" data-level="${item.level}" data-category="${item.category}">
+    <div class="vocab-card search-result"
+      data-word="${escapeHtml(item.word.toLowerCase())}" 
+      data-translation="${escapeHtml(item.translation.toLowerCase())}" 
+      data-level="${escapeHtml(item.level)}" 
+      data-category="${escapeHtml(item.category)}">
       <div class="vocab-card-inner">
         <div class="vocab-card-front">
-          <div class="vocab-word">${highlightMatch(item.word, query)}</div>
+          <div class="vocab-word">${highlightMatch(escapeHtml(item.word), escapeHtml(query))}</div>
           <div class="vocab-meta">
-            <span class="level-badge level-${item.level.toLowerCase()}">${item.level}</span>
-            <span class="category-tag">${item.category}</span>
-            <span class="difficulty-indicator" title="Difficulty: ${item.difficulty}/5">
+            <span class="level-badge level-${escapeHtml(item.level.toLowerCase())}">${escapeHtml(item.level)}</span>
+            <span class="category-tag">${escapeHtml(item.category)}</span>
+            <span class="difficulty-indicator" title="Difficulty: ${escapeHtml(item.difficulty)}/5">
               ${'★'.repeat(item.difficulty)}${'☆'.repeat(5 - item.difficulty)}
             </span>
           </div>


### PR DESCRIPTION
Potential fix for [https://github.com/YungSeepferd/BulgarianGermanLearningApp/security/code-scanning/5](https://github.com/YungSeepferd/BulgarianGermanLearningApp/security/code-scanning/5)

To fix this vulnerability, we must ensure all user-derived or potentially attacker-controlled data interpolated into the dynamically generated HTML is properly escaped before being injected via `innerHTML`. The best approach is to HTML-escape all interpolated values that may contain user input inside the template literal used in `resultsContainer.innerHTML = ...`. This involves replacing direct usage of e.g. `${item.word}` with `${escapeHtml(item.word)}` for every field that is not guaranteed safe. We need to add an appropriate `escapeHtml` function in the same script block to handle character escaping (`<`, `>`, `&`, `'`, `"`). For cases like `highlightMatch(item.word, query)`, we must ensure that this function also escapes before applying any highlighting, or escape after highlighting so the output does not contain dangerous HTML unless intended for markup. In summary: add an `escapeHtml` function, and replace all direct interpolations of user-derived values with their escaped equivalents in the innerHTML assignment.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
