### PR TITLE
Potential fix for code scanning alert no. 8: DOM text reinterpreted as HTML

### DIFF
--- a/layouts/shortcodes/vocab-search.html
+++ b/layouts/shortcodes/vocab-search.html
@@ -243,27 +243,31 @@ function displayResults(results, query, searchTime) {
           </div>
         </div>
         <div class="vocab-card-back">
-          <div class="vocab-translation">${highlightMatch(item.translation, query)}</div>
-          ${item.notes ? `<div class="vocab-notes">${highlightMatch(item.notes, query)}</div>` : ''}
-          ${item.etymology ? `<div class="vocab-etymology"><strong>Etymology:</strong> ${item.etymology}</div>` : ''}
-          ${item.cultural_note ? `<div class="vocab-cultural-note"><strong>Cultural Note:</strong> ${item.cultural_note}</div>` : ''}
-          ${item.linguistic_note ? `<div class="vocab-linguistic-note"><strong>Linguistic Note:</strong> ${item.linguistic_note}</div>` : ''}
+          <div class="vocab-translation">${highlightMatch(escapeHtml(item.translation), escapeHtml(query))}</div>
+          ${item.notes ? `<div class="vocab-notes">${highlightMatch(escapeHtml(item.notes), escapeHtml(query))}</div>` : ''}
+          ${item.etymology ? `<div class="vocab-etymology"><strong>Etymology:</strong> ${escapeHtml(item.etymology)}</div>` : ''}
+          ${item.cultural_note ? `<div class="vocab-cultural-note"><strong>Cultural Note:</strong> ${escapeHtml(item.cultural_note)}</div>` : ''}
+          ${item.linguistic_note ? `<div class="vocab-linguistic-note"><strong>Linguistic Note:</strong> ${escapeHtml(item.linguistic_note)}</div>` : ''}
         </div>
       </div>
       <div class="vocab-card-actions">
         <button class="flip-btn" onclick="this.closest('.vocab-card').classList.toggle('flipped')">↻</button>
-        <button class="practice-btn" data-word="${item.word}">Practice</button>
-        <input type="checkbox" class="select-checkbox" data-word="${item.word}">
+        <button class="practice-btn" data-word="${escapeHtml(item.word)}">Practice</button>
+        <input type="checkbox" class="select-checkbox" data-word="${escapeHtml(item.word)}">
       </div>
     </div>
   `).join('');
 }
+  // text is assumed HTML-escaped. This will safely wrap matched fragments in <mark>.
 
 function highlightMatch(text, query) {
   if (!query || !text) return text;
   
   const regex = new RegExp(`(${escapeRegex(query)})`, 'gi');
-  return text.replace(regex, '<mark>$1</mark>');
+  // Replace all matches with <mark> ... </mark>, no risk of user HTML injection in content.
+  return text.replace(regex, function(match) {
+    return `<mark>${match}</mark>`;
+  });
 }
 
 function escapeRegex(string) {


### PR DESCRIPTION
Potential fix for [https://github.com/YungSeepferd/BulgarianGermanLearningApp/security/code-scanning/8](https://github.com/YungSeepferd/BulgarianGermanLearningApp/security/code-scanning/8)

To fix this issue, ensure that all data interpolated into HTML **via `innerHTML` or otherwise interpreted as HTML** is properly escaped. Data that is included as part of HTML attributes (e.g., `data-word`, `data-translation`) is already passed through `escapeHtml` and is safe, but fields such as `item.translation`, `item.notes`, `item.etymology`, `item.cultural_note`, and `item.linguistic_note` — when rendered via template literals and through `highlightMatch()` — must be fully escaped **after** highlighting the search matches to prevent unescaped user input from being interpreted as HTML. 

The safest way is for `highlightMatch()` to return text where only the matched substring is wrapped in `<mark>`, and all other content is otherwise HTML-escaped. This can be done by:
- Escaping the string first, i.e., before applying the regex-based replace for marking.
- When processing fields like `item.translation`, `item.notes`, etc., always apply escaping via `escapeHtml` first, then highlight matches (with a modified function that works on escaped strings).
- For the optional fields inserted via template literals (`${item.etymology}`, etc.), also apply `escapeHtml` and, if relevant, `highlightMatch` (for search query matches), ensuring that escaping is done first and matches are highlighted only on safe text.

In addition, rework `highlightMatch()` so it does not return unescaped user-controlled content as HTML, or escape the values after highlighting and before interpolating into the DOM.

The required changes are:
- Update all interpolations of potentially tainted values so they are always escaped when inserted as HTML (either via string interpolation or as attributes).
- Ensure `highlightMatch` produces safe HTML (perform escaping, then replace, then *not* escape again only the inserted `<mark>`).
- Apply the fix in the string templating in `displayResults`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
